### PR TITLE
fixed table detection for []*T

### DIFF
--- a/dbmap.go
+++ b/dbmap.go
@@ -17,12 +17,13 @@ import (
 	"log"
 	"reflect"
 	"strings"
+
 	"github.com/jmoiron/sqlx"
 )
 
 // TableNameMapper is the function used by AddTable to map struct names to database table names, in analogy
 // to sqlx.NameMapper which does the same for struct field name to database column names.
-var TableNameMapper  = strings.ToLower
+var TableNameMapper = strings.ToLower
 
 // DbMap is the root modl mapping object. Create one of these for each
 // database schema you wish to map.  Each DbMap contains a list of
@@ -374,6 +375,9 @@ start:
 		t = v.Type().Elem()
 	default:
 		t = v.Type()
+	}
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
 	}
 	return m.TableForType(t)
 }

--- a/modl_test.go
+++ b/modl_test.go
@@ -385,6 +385,7 @@ func TestHooks(t *testing.T) {
 		t.Errorf("p1.PostGet() didn't run: %v", p1)
 	}
 
+	p1.LName = "smith"
 	_update(dbmap, p1)
 	if p1.FName != "preupdate" {
 		t.Errorf("p1.PreUpdate() didn't run: %v", p1)


### PR DESCRIPTION
PostGet wasn't being run for records fetched into []*T using Select because the last pointer wasn't followed and no table mapping could be found.

TestHooks was a false positive for this case because the _update() call overwrote the value with the expected one, set by the previous call to PostGet.
