### PR TITLE
compatible with withmock

### DIFF
--- a/dbmap.go
+++ b/dbmap.go
@@ -287,7 +287,7 @@ func (m *DbMap) Update(list ...interface{}) (int64, error) {
 // Returns an error if SetKeys has not been called on the TableMap or if
 // any interface in the list has not been registered with AddTable
 func (m *DbMap) Delete(list ...interface{}) (int64, error) {
-	return delete(m, m, list...)
+	return deletes(m, m, list...)
 }
 
 // Get runs a SQL SELECT to fetch a single row from the table based on the

--- a/modl.go
+++ b/modl.go
@@ -125,7 +125,10 @@ type SqlExecutor interface {
 
 // Compile-time check that DbMap and Transaction implement the SqlExecutor
 // interface.
-var _, _ SqlExecutor = &DbMap{}, &Transaction{}
+var (
+        _ SqlExecutor = &DbMap{}
+        _ SqlExecutor = &Transaction{}
+)
 
 ///////////////
 
@@ -203,7 +206,7 @@ func get(m *DbMap, e SqlExecutor, dest interface{}, keys ...interface{}) error {
 	return nil
 }
 
-func delete(m *DbMap, e SqlExecutor, list ...interface{}) (int64, error) {
+func deletes(m *DbMap, e SqlExecutor, list ...interface{}) (int64, error) {
 	var err error
 	var table *TableMap
 	var elem reflect.Value

--- a/transaction.go
+++ b/transaction.go
@@ -27,7 +27,7 @@ func (t *Transaction) Update(list ...interface{}) (int64, error) {
 
 // Delete has the same behavior as DbMap.Delete(), but runs in a transaction.
 func (t *Transaction) Delete(list ...interface{}) (int64, error) {
-	return delete(t.dbmap, t, list...)
+	return deletes(t.dbmap, t, list...)
 }
 
 // Get has the Same behavior as DbMap.Get(), but runs in a transaction.


### PR DESCRIPTION
make modl compatible with withmock mocking library.
1) change multiple var decleration, which no supported via withmock;
2) change delete to deletes to avoid overriding builtin function delete, which is used via withmock
