### PR TITLE
Work around database/sql not being able to write large uint64 values

### DIFF
--- a/modl.go
+++ b/modl.go
@@ -83,18 +83,26 @@ func (plan bindPlan) createBindInstance(elem reflect.Value) bindInstance {
 				elem.FieldByName(plan.versField).SetInt(int64(newVer))
 			}
 		} else {
-			val := elem.FieldByName(k).Interface()
-			bi.args = append(bi.args, val)
+			bi.args = append(bi.args, getFieldValue(elem, k))
 		}
 	}
 
 	for i := 0; i < len(plan.keyFields); i++ {
 		k := plan.keyFields[i]
-		val := elem.FieldByName(k).Interface()
-		bi.keys = append(bi.keys, val)
+		bi.keys = append(bi.keys, getFieldValue(elem, k))
 	}
 
 	return bi
+}
+
+func getFieldValue(elem reflect.Value, name string) interface{} {
+	val := elem.FieldByName(name).Interface()
+	u64, isUint64 := val.(uint64)
+	if !isUint64 {
+		return val
+	}
+	
+	return fmt.Sprintf("%d", u64)
 }
 
 type bindInstance struct {

--- a/tablemap.go
+++ b/tablemap.go
@@ -3,10 +3,9 @@ package modl
 import (
 	"bytes"
 	"fmt"
-	"reflect"
-
 	"github.com/jmoiron/sqlx"
 	"github.com/jmoiron/sqlx/reflectx"
+	"reflect"
 )
 
 // TableMap represents a mapping between a Go struct and a database table
@@ -259,7 +258,12 @@ func (t *TableMap) bindInsert(elem reflect.Value) bindInstance {
 					s2.WriteString(t.dbmap.Dialect.AutoIncrBindValue())
 					plan.autoIncrIdx = y
 				} else {
-					s2.WriteString(t.dbmap.Dialect.BindVar(x))
+					if elem.FieldByName(col.fieldName).Kind() == reflect.Uint64 {
+						s2.WriteString(fmt.Sprintf("CAST(%s AS NUMERIC)", t.dbmap.Dialect.BindVar(x)))
+					} else {
+						s2.WriteString(t.dbmap.Dialect.BindVar(x))
+					}
+
 					if col == t.version {
 						plan.versField = col.fieldName
 						plan.argFields = append(plan.argFields, versFieldConst)


### PR DESCRIPTION
Go's sql package has this extremely weird restriction of not allowing to store uint64 with the highest bit set:
- [Issue 6113:  database/sql: why can't you use uint64 with high bits set?](https://code.google.com/p/go/issues/detail?id=6113)
- [Comment on database/sql type limitations](https://groups.google.com/forum/#!topic/golang-nuts/fTNwEzFEFP4)

I needed a quick solution for a project, so I worked around this using the applied patch. It is tested with SQLite only.

Please decide if this is the right way to work around the issue and how to proceed from here.
