### PR TITLE
"Could not find table for" error displays type instead of always <nil>

### DIFF
--- a/tablemap.go
+++ b/tablemap.go
@@ -366,7 +366,7 @@ func tableForPointer(m *DbMap, i interface{}, checkPk bool) (*TableMap, reflect.
 	v = v.Elem()
 	t := m.TableForType(v.Type())
 	if t == nil {
-		return nil, v, fmt.Errorf("could not find table for %v", t)
+		return nil, v, fmt.Errorf("could not find table for %v", v.Type())
 	}
 	if checkPk && len(t.Keys) < 1 {
 		return t, v, &NoKeysErr{t}


### PR DESCRIPTION
`t` is always nil when displaying the message, making it `could not find table for <nil>` 100% of the time.