### PR TITLE
Not nullable support and dialect fixes

### DIFF
--- a/dbmap.go
+++ b/dbmap.go
@@ -177,11 +177,20 @@ func writeColumnSql(sql *bytes.Buffer, col *ColumnMap) {
 		sqltype = col.table.dbmap.Dialect.ToSqlType(col)
 	}
 	sql.WriteString(fmt.Sprintf("%s %s", col.table.dbmap.Dialect.QuoteField(col.ColumnName), sqltype))
+
+	// Expand to support sql pkg nullables
+	nullable := col.gotype.Kind() == reflect.Ptr
+
 	if col.isPK {
 		sql.WriteString(" not null")
 		if len(col.table.Keys) == 1 {
 			sql.WriteString(" primary key")
 		}
+		if nullable {
+			log.Println("WARNING: PK Should never be nullable")
+		}
+	} else if !nullable {
+		sql.WriteString(" not null")
 	}
 	if col.Unique {
 		sql.WriteString(" unique")

--- a/dbmap.go
+++ b/dbmap.go
@@ -124,7 +124,7 @@ func (m *DbMap) AddTable(i interface{}, name ...string) *TableMap {
 			ColumnName: columnName,
 			Transient:  columnName == "-",
 			fieldName:  f.Name,
-			gotype:     f.Type,
+			Gotype:     f.Type,
 			table:      tmap,
 		}
 		tmap.Columns = append(tmap.Columns, cm)
@@ -180,12 +180,12 @@ func writeColumnSql(sqlBuf *bytes.Buffer, col *ColumnMap) {
 
 	// Check for a nullable type
 	nullable := col.Nullable
-	switch col.gotype.Kind() {
+	switch col.Gotype.Kind() {
 	case reflect.Ptr, reflect.Slice, reflect.Array, reflect.Interface:
 		nullable = true
 	default:
 		// Need to get a ptr type for this
-		goPtrType := reflect.PtrTo(col.gotype)
+		goPtrType := reflect.PtrTo(col.Gotype)
 
 		// See if this implement scanner
 		if goPtrType.Implements(reflect.TypeOf((*sql.Scanner)(nil)).Elem()) {
@@ -207,7 +207,7 @@ func writeColumnSql(sqlBuf *bytes.Buffer, col *ColumnMap) {
 	if col.Unique {
 		sqlBuf.WriteString(" unique")
 	}
-	if col.isAutoIncr {
+	if col.IsAutoIncr {
 		sqlBuf.WriteString(" " + col.table.dbmap.Dialect.AutoIncrStr())
 	}
 }

--- a/dialect.go
+++ b/dialect.go
@@ -94,7 +94,12 @@ func (d SqliteDialect) DriverName() string {
 
 // ToSqlType maps go types to sqlite types.
 func (d SqliteDialect) ToSqlType(col *ColumnMap) string {
-	switch col.Gotype.Kind() {
+	gotype := col.Gotype
+	if col.Gotype.Kind() == reflect.Ptr {
+		gotype = gotype.Elem()
+	}
+
+	switch gotype.Kind() {
 	case reflect.Bool:
 		return "integer"
 	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint16, reflect.Uint32, reflect.Uint64:
@@ -102,7 +107,7 @@ func (d SqliteDialect) ToSqlType(col *ColumnMap) string {
 	case reflect.Float64, reflect.Float32:
 		return "real"
 	case reflect.Slice:
-		if col.Gotype.Elem().Kind() == reflect.Uint8 {
+		if gotype.Elem().Kind() == reflect.Uint8 {
 			return "blob"
 		}
 	}
@@ -114,7 +119,7 @@ func (d SqliteDialect) ToSqlType(col *ColumnMap) string {
 		return "real"
 	case "NullableBool":
 		return "integer"
-	case "NullableBytes":
+	case "RawBytes":
 		return "blob"
 	case "Time", "NullTime":
 		return "datetime"
@@ -190,8 +195,12 @@ func (d PostgresDialect) DriverName() string {
 
 // ToSqlType maps go types to postgres types.
 func (d PostgresDialect) ToSqlType(col *ColumnMap) string {
+	gotype := col.Gotype
+	if col.Gotype.Kind() == reflect.Ptr {
+		gotype = gotype.Elem()
+	}
 
-	switch col.Gotype.Kind() {
+	switch gotype.Kind() {
 	case reflect.Bool:
 		return "boolean"
 	case reflect.Int, reflect.Int16, reflect.Int32, reflect.Uint16, reflect.Uint32:
@@ -207,7 +216,7 @@ func (d PostgresDialect) ToSqlType(col *ColumnMap) string {
 	case reflect.Float64, reflect.Float32:
 		return "real"
 	case reflect.Slice:
-		if col.Gotype.Elem().Kind() == reflect.Uint8 {
+		if gotype.Elem().Kind() == reflect.Uint8 {
 			return "bytea"
 		}
 	}
@@ -219,9 +228,9 @@ func (d PostgresDialect) ToSqlType(col *ColumnMap) string {
 		return "double"
 	case "NullableBool":
 		return "smallint"
-	case "NullableBytes":
+	case "RawBytes":
 		return "bytea"
-	case "Time", "Nulltime":
+	case "Time", "NullTime":
 		return "timestamp with time zone"
 	}
 

--- a/modl.go
+++ b/modl.go
@@ -126,8 +126,8 @@ type SqlExecutor interface {
 // Compile-time check that DbMap and Transaction implement the SqlExecutor
 // interface.
 var (
-        _ SqlExecutor = &DbMap{}
-        _ SqlExecutor = &Transaction{}
+	_ SqlExecutor = &DbMap{}
+	_ SqlExecutor = &Transaction{}
 )
 
 ///////////////

--- a/tablemap.go
+++ b/tablemap.go
@@ -56,7 +56,7 @@ func (t *TableMap) SetKeys(isAutoIncr bool, fieldNames ...string) *TableMap {
 		// own API which sets sqlx's mapping funcs as necessary
 		colmap := t.ColMap(sqlx.NameMapper(name))
 		colmap.isPK = true
-		colmap.isAutoIncr = isAutoIncr
+		colmap.IsAutoIncr = isAutoIncr
 		t.Keys = append(t.Keys, colmap)
 	}
 	t.ResetSql()
@@ -255,7 +255,7 @@ func (t *TableMap) bindInsert(elem reflect.Value) bindInstance {
 				}
 				s.WriteString(t.dbmap.Dialect.QuoteField(col.ColumnName))
 
-				if col.isAutoIncr {
+				if col.IsAutoIncr {
 					s2.WriteString(t.dbmap.Dialect.AutoIncrBindValue())
 					plan.autoIncrIdx = y
 				} else {
@@ -313,12 +313,16 @@ type ColumnMap struct {
 	// the table this column belongs to
 	table *TableMap
 
-	fieldName  string
-	gotype     reflect.Type
-	sqltype    string
-	createSql  string
-	isPK       bool
-	isAutoIncr bool
+	// The reflect.Type of this column
+	Gotype reflect.Type
+
+	// If true, column is auto incremented
+	IsAutoIncr bool
+
+	fieldName string
+	sqltype   string
+	createSql string
+	isPK      bool
 }
 
 // SetTransient allows you to mark the column as transient. If true

--- a/tablemap.go
+++ b/tablemap.go
@@ -302,6 +302,10 @@ type ColumnMap struct {
 	// If true, " unique" is added to create table statements.
 	Unique bool
 
+	// Used to make nullable columns for types that normally
+	// would be not nullable (e.g. pointers and sql.Scanner)
+	Nullable bool
+
 	// Passed to Dialect.ToSqlType() to assist in informing the
 	// correct column type to map to in CreateTables()
 	MaxSize int
@@ -328,6 +332,13 @@ func (c *ColumnMap) SetTransient(b bool) *ColumnMap {
 // will be added to create table statements for this column.
 func (c *ColumnMap) SetUnique(b bool) *ColumnMap {
 	c.Unique = b
+	return c
+}
+
+// SetNullable remove the not nullable clause for this column.  If true, the
+// not nullable will not be added to create table statements for this column.
+func (c *ColumnMap) SetNullable(b bool) *ColumnMap {
+	c.Nullable = b
 	return c
 }
 


### PR DESCRIPTION
Currently all fields when created are left to the database default in terms of being nullable or not nullable - generally this means nullable. Primary drawback to this is performance. I've address this by making not nullable the default, overridable by column, but making slices, ptrs, arrays, interfaces and sql.Scanner as nullable.

The Dialects were also updated to deal with pointers in ToSqlType, use RawBytes instead of NullableBytes (a typo it seems) and NullTime instead of Nulltime (postgresql dialect typo).

Dialects similarly could not be made outside of the package because a few of the ColumnMap fields were private, these were made public.
