### PR TITLE
Fix gorp link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Godoc](http://img.shields.io/badge/godoc-reference-blue.svg?style=flat)](https://godoc.org/github.com/jmoiron/modl)
 
 Modl is a library which provides database modelling and mapping.   It is a fork of
-James Cooper's wonderful [gorp](http://github.com/coopernurse/gorp).
+James Cooper's wonderful [gorp](https://github.com/go-gorp/gorp).
 
 **Note**.  Modl's public facing interface is considered unfinished and open to
 change.  The current API will not be broken lightly, but additions are likely.


### PR DESCRIPTION
The README at the currently linked gorp says:

> We've moved!
> gorp is now officially maintained at:
> 
> https://github.com/go-gorp/gorp
> 
> This fork was created when the project was moved, and is provided for backwards compatibility for old projects, but no guarantees are made on how up to date it will be.
> 
> You're encouraged to update your import statements to use the official go-gorp version above.
> 
> Thank you!